### PR TITLE
Enhance image upload support by adding SVG format to allowed types 

### DIFF
--- a/src/components/ui/ImageUpload.tsx
+++ b/src/components/ui/ImageUpload.tsx
@@ -179,7 +179,7 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
             </div>
             <p className="text-sm font-medium text-gray-700 mb-1">{placeholder}</p>
             <p className="text-xs text-gray-500 mb-1">
-              PNG, JPG, JPEG, WEBP up to {maxSize}MB
+              PNG, JPG, JPEG, SVG, WEBP up to {maxSize}MB
             </p>
             <button
               type="button"

--- a/src/pages/superadmin/shop-management/components/MultiStepProductForm.tsx
+++ b/src/pages/superadmin/shop-management/components/MultiStepProductForm.tsx
@@ -387,7 +387,7 @@ const MultiStepProductForm: React.FC<MultiStepProductFormProps> = ({
       setStepErrors(prev => ({ ...prev, 3: '' }));
       
       // Frontend validation - only for new media, skip existing media
-      const validImageTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp'];
+      const validImageTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/svg', 'image/webp'];
       const validVideoTypes = ['video/mp4', 'video/mov', 'video/avi'];
       const maxImageSize = 5 * 1024 * 1024; // 5MB
       const maxVideoSize = 50 * 1024 * 1024; // 50MB
@@ -400,7 +400,7 @@ const MultiStepProductForm: React.FC<MultiStepProductFormProps> = ({
         
         if (media.type === 'image') {
           if (!validImageTypes.includes(media.file.type)) {
-            throw new Error('Invalid image format. Please use JPEG, PNG, or WebP.');
+            throw new Error('Invalid image format. Please use JPEG, PNG, SVG, or WebP.');
           }
           if (media.file.size > maxImageSize) {
             throw new Error('Image size must be less than 5MB.');

--- a/src/pages/superadmin/shop-management/components/steps/MediaStep.tsx
+++ b/src/pages/superadmin/shop-management/components/steps/MediaStep.tsx
@@ -28,7 +28,7 @@ const MediaStep: React.FC<MediaStepProps> = ({ data, onChange }) => {
   const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
   const MAX_VIDEO_SIZE = 50 * 1024 * 1024; // 50MB
   
-  const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp'];
+  const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp', 'image/svg'];
   const ALLOWED_VIDEO_TYPES = ['video/mp4', 'video/mov', 'video/avi'];
 
   const imageCount = data.filter(item => item.type === 'image').length;
@@ -47,7 +47,7 @@ const MediaStep: React.FC<MediaStepProps> = ({ data, onChange }) => {
         return `Maximum ${MAX_IMAGES} images allowed`;
       }
       if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
-        return 'Invalid image format. Please use JPEG, PNG, or WebP';
+        return 'Invalid image format. Please use JPEG, PNG, SVG, or WebP';
       }
       if (file.size > MAX_IMAGE_SIZE) {
         return 'Image size must be less than 5MB';
@@ -245,7 +245,7 @@ const MediaStep: React.FC<MediaStepProps> = ({ data, onChange }) => {
         <ul className="text-sm text-blue-800 space-y-1">
           <li>• Maximum {MAX_IMAGES} images (at least 1 required)</li>
           <li>• Maximum {MAX_VIDEOS} video (optional)</li>
-          <li>• Images: Max 5MB each (JPEG, PNG, WebP)</li>
+          <li>• Images: Max 5MB each (JPEG, PNG, SVG, WebP)</li>
           <li>• Videos: Max 50MB (MP4, MOV, AVI - will be converted to MP4)</li>
         </ul>
       </div>


### PR DESCRIPTION
This pull request updates the supported image formats across multiple components to include SVG in addition to the previously supported formats (JPEG, PNG, and WebP). The changes ensure consistency in validation, error messages, and user-facing instructions.

### Expanded Image Format Support:
* [`src/components/ui/ImageUpload.tsx`](diffhunk://#diff-b60357b97d220465fc16d2d12a04d02cddb433be70b521010937df87ef5387f7L182-R182): Updated the placeholder text to include SVG as a supported image format.
* `src/pages/superadmin/shop-management/components/MultiStepProductForm.tsx`: 
  - Added SVG to the list of valid image types for frontend validation.
  - Updated the error message for invalid image formats to include SVG.
* `src/pages/superadmin/shop-management/components/steps/MediaStep.tsx`: 
  - Added SVG to the allowed image types for validation.
  - Updated the error message for invalid image formats to include SVG.
  - Updated the user-facing instructions to list SVG as a supported image format.