### PR TITLE
fix: update variant media handling in MultiStepProductForm to use correct response structure

### DIFF
--- a/src/pages/superadmin/shop-management/components/MultiStepProductForm.tsx
+++ b/src/pages/superadmin/shop-management/components/MultiStepProductForm.tsx
@@ -624,8 +624,8 @@ const MultiStepProductForm: React.FC<MultiStepProductFormProps> = ({
             const createResult = await shopManagementService.createVariant(createdProductId, variantData);
             
             // Handle media separately for new variants
-            if (variant.media && variant.media.length > 0 && createResult?.variant_product_id) {
-              await saveVariantMedia(variant, createResult.variant_product_id);
+            if (variant.media && variant.media.length > 0 && createResult?.message?.variant?.variant_product_id) {
+              await saveVariantMedia(variant, createResult.message.variant.variant_product_id);
             }
           }
         }
@@ -656,6 +656,8 @@ const MultiStepProductForm: React.FC<MultiStepProductFormProps> = ({
             // Handle variant media if any
             media: variant.media.filter(m => !m.isExisting).map((media, mediaIndex) => ({
               type: media.type.toUpperCase(),
+              url: media.url,
+              public_id: (media as any).public_id,
               file_size: media.file?.size,
               file_name: media.file?.name,
               is_primary: media.is_primary,


### PR DESCRIPTION
This pull request updates the `MultiStepProductForm` component to fix issues with handling variant media and improve its data structure. The most important changes include updating how the `variant_product_id` is accessed and adding new fields to the media object.

### Fixes and improvements to variant media handling:

* Updated the logic to access `variant_product_id` from `createResult.message.variant.variant_product_id` instead of `createResult.variant_product_id` to align with the updated API response structure. (`src/pages/superadmin/shop-management/components/MultiStepProductForm.tsx`, [src/pages/superadmin/shop-management/components/MultiStepProductForm.tsxL627-R628](diffhunk://#diff-9dd3d487a05f9522c2287aaa9b4750518a57176b90f5a3b55e76fcea72586cceL627-R628))
* Added `url` and `public_id` fields to the media object when mapping variant media, ensuring more comprehensive data is included for each media item. (`src/pages/superadmin/shop-management/components/MultiStepProductForm.tsx`, [src/pages/superadmin/shop-management/components/MultiStepProductForm.tsxR659-R660](diffhunk://#diff-9dd3d487a05f9522c2287aaa9b4750518a57176b90f5a3b55e76fcea72586cceR659-R660))