### PR TITLE
feat(add):  new responsive order confirmation page for each shop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import Shop3Wishlist from './pages/Shop/Shop3Wishlist';
 import Shop4Wishlist from './pages/Shop/Shop4Wishlist';
 import { Shop1Cart, Shop2Cart, Shop3Cart, Shop4Cart } from './pages/Shop/ShopCartWrapper';
 import { Shop1Order, Shop2Order, Shop3Order, Shop4Order } from './pages/Shop/ShopOrderWrapper';
+import { Shop1OrderConfirmation, Shop2OrderConfirmation, Shop3OrderConfirmation, Shop4OrderConfirmation } from './pages/Shop/ShopOrderConfirmationWrapper';
 import PasswordReset from './pages/auth/PasswordReset';
 import VerifyEmail from './pages/auth/VerifyEmail';
 import RequestPasswordReset from './pages/auth/RequestPasswordReset';
@@ -265,6 +266,10 @@ const App: React.FC = () => {
                     <Route path="/shop2/order" element={<Shop2Order />} />
                     <Route path="/shop3/order" element={<Shop3Order />} />
                     <Route path="/shop4/order" element={<Shop4Order />} />
+                    <Route path="/shop1/order-confirmation" element={<Shop1OrderConfirmation />} />
+                    <Route path="/shop2/order-confirmation" element={<Shop2OrderConfirmation />} />
+                    <Route path="/shop3/order-confirmation" element={<Shop3OrderConfirmation />} />
+                    <Route path="/shop4/order-confirmation" element={<Shop4OrderConfirmation />} />
                     
                     <Route
                       path="/business/login"

--- a/src/pages/Shop/ShopOrder.tsx
+++ b/src/pages/Shop/ShopOrder.tsx
@@ -2,9 +2,70 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
 import { useShopCartOperations } from '../../context/ShopCartContext';
-import { shopCartService, ShopCartItem } from '../../services/shopCartService';
 import { toast } from 'react-hot-toast';
-import ShopCartSummary from '../../components/ShopCartSummary';
+import { MapPin, Edit2, Trash2, ChevronDown, CreditCard, Plus, X } from 'lucide-react';
+import ConfirmationModal from '../../components/common/ConfirmationModal';
+
+// Local interfaces to match what the API actually returns
+interface ShopCartItem {
+  cart_item_id: number;
+  shop_product_id: number;
+  quantity: number;
+  selected_attributes: { [key: number]: string | string[] };
+  product: {
+    name: string;
+    price: number;
+    original_price: number;
+    special_price?: number;
+    image_url: string;
+    stock: number;
+    is_deleted: boolean;
+  };
+}
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+// Country phone codes
+const COUNTRY_CODES = [
+  { code: "US", name: "United States", phoneCode: "+1" },
+  { code: "GB", name: "United Kingdom", phoneCode: "+44" },
+  { code: "CA", name: "Canada", phoneCode: "+1" },
+  { code: "AU", name: "Australia", phoneCode: "+61" },
+  { code: "IN", name: "India", phoneCode: "+91" },
+  { code: "AE", name: "UAE", phoneCode: "+971" },
+  { code: "SA", name: "Saudi Arabia", phoneCode: "+966" },
+];
+
+interface Address {
+  address_id: number;
+  contact_name: string;
+  contact_phone: string;
+  address_line1: string;
+  address_line2?: string;
+  landmark?: string;
+  city: string;
+  state_province: string;
+  postal_code: string;
+  country_code: string;
+  address_type: "shipping" | "billing";
+  is_default_shipping: boolean;
+  is_default_billing: boolean;
+}
+
+interface PaymentCard {
+  card_id: number;
+  user_id: number;
+  card_type: "credit" | "debit";
+  last_four_digits: string;
+  card_holder_name: string;
+  card_brand: string;
+  status: "active" | "expired" | "suspended" | "deleted";
+  is_default: boolean;
+  billing_address: Address | null;
+  last_used_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
 
 interface ShopOrderProps {
   shopId: number;
@@ -19,17 +80,40 @@ const ShopOrder: React.FC<ShopOrderProps> = ({ shopId, shopName }) => {
   const [cartItems, setCartItems] = useState<ShopCartItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isPlacingOrder, setIsPlacingOrder] = useState(false);
-  const [customerDetails, setCustomerDetails] = useState({
-    firstName: '',
-    lastName: '',
-    email: '',
-    phone: '',
-    address: '',
-    city: '',
-    state: '',
-    zipCode: '',
-    country: ''
+  
+  // Address management states
+  const [addresses, setAddresses] = useState<Address[]>([]);
+  const [selectedAddressId, setSelectedAddressId] = useState<number | null>(null);
+  const [showAddressForm, setShowAddressForm] = useState(false);
+  const [editingAddressId, setEditingAddressId] = useState<number | null>(null);
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  const [addressToDelete, setAddressToDelete] = useState<Address | null>(null);
+  
+  // Payment method states
+  const [paymentMethod, setPaymentMethod] = useState("cash_on_delivery");
+  const [savedCards, setSavedCards] = useState<PaymentCard[]>([]);
+  const [selectedCardId, setSelectedCardId] = useState<number | null>(null);
+  const [showCardForm, setShowCardForm] = useState(false);
+  
+  // Address form states
+  const [showCountryCodes, setShowCountryCodes] = useState(false);
+  const [selectedCountry, setSelectedCountry] = useState(COUNTRY_CODES.find(c => c.code === "IN") || COUNTRY_CODES[0]);
+  const [addressFormData, setAddressFormData] = useState({
+    contact_name: "",
+    contact_phone: "",
+    address_line1: "",
+    address_line2: "",
+    landmark: "",
+    city: "",
+    state_province: "",
+    postal_code: "",
+    country_code: "IN",
+    address_type: "shipping" as "shipping" | "billing",
+    is_default_shipping: true,
+    is_default_billing: false,
   });
+  
+  const [savingAddress, setSavingAddress] = useState(false);
 
   useEffect(() => {
     if (!isAuthenticated) {
@@ -44,6 +128,8 @@ const ShopOrder: React.FC<ShopOrderProps> = ({ shopId, shopName }) => {
     }
 
     loadCartItems();
+    loadAddresses();
+    loadPaymentCards();
   }, [isAuthenticated, user, shopId]);
 
   const loadCartItems = async () => {
@@ -59,11 +145,227 @@ const ShopOrder: React.FC<ShopOrderProps> = ({ shopId, shopName }) => {
     }
   };
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    const { name, value } = e.target;
-    setCustomerDetails(prev => ({
+  const loadAddresses = async () => {
+    if (!user?.id) return;
+    
+    try {
+      const token = localStorage.getItem("access_token");
+      if (!token) return;
+
+      const baseUrl = API_BASE_URL.replace(/\/+$/, "");
+      const url = `${baseUrl}/api/user-address?user_id=${user.id}`;
+      
+      const response = await fetch(url, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        console.log('Address API response:', data); // Debug log
+        if (data.addresses) {
+          setAddresses(data.addresses);
+          // Auto-select default shipping address
+          const defaultShipping = data.addresses.find((addr: Address) => addr.is_default_shipping);
+          if (defaultShipping) {
+            setSelectedAddressId(defaultShipping.address_id);
+          }
+        }
+      }
+    } catch (error) {
+      console.error('Failed to load addresses:', error);
+    }
+  };
+
+  const loadPaymentCards = async () => {
+    if (!user?.id) return;
+    
+    try {
+      const token = localStorage.getItem("access_token");
+      if (!token) return;
+
+      const baseUrl = API_BASE_URL.replace(/\/+$/, "");
+      const response = await fetch(`${baseUrl}/api/payment-cards`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        if (data.status === 'success' && data.data) {
+          setSavedCards(data.data);
+          // Auto-select default card
+          const defaultCard = data.data.find((card: PaymentCard) => card.is_default);
+          if (defaultCard) {
+            setSelectedCardId(defaultCard.card_id);
+          }
+        }
+      }
+    } catch (error) {
+      console.error('Failed to load payment cards:', error);
+    }
+  };
+
+  const handleAddressSelect = (address: Address) => {
+    setSelectedAddressId(address.address_id);
+  };
+
+  const handleAddNewAddress = () => {
+    setEditingAddressId(null);
+    setAddressFormData({
+      contact_name: "",
+      contact_phone: "",
+      address_line1: "",
+      address_line2: "",
+      landmark: "",
+      city: "",
+      state_province: "",
+      postal_code: "",
+      country_code: "IN",
+      address_type: "shipping",
+      is_default_shipping: addresses.length === 0,
+      is_default_billing: false,
+    });
+    setSelectedCountry(COUNTRY_CODES.find(c => c.code === "IN") || COUNTRY_CODES[0]);
+    setShowAddressForm(true);
+  };
+
+  const handleEditAddress = (addressId: number) => {
+    const address = addresses.find(addr => addr.address_id === addressId);
+    if (address) {
+      setEditingAddressId(addressId);
+      setAddressFormData({
+        contact_name: address.contact_name,
+        contact_phone: address.contact_phone,
+        address_line1: address.address_line1,
+        address_line2: address.address_line2 || "",
+        landmark: address.landmark || "",
+        city: address.city,
+        state_province: address.state_province,
+        postal_code: address.postal_code,
+        country_code: address.country_code,
+        address_type: address.address_type,
+        is_default_shipping: address.is_default_shipping,
+        is_default_billing: address.is_default_billing,
+      });
+      const country = COUNTRY_CODES.find(c => c.code === address.country_code);
+      if (country) setSelectedCountry(country);
+      setShowAddressForm(true);
+    }
+  };
+
+  const handleDeleteAddress = async (addressId: number) => {
+    try {
+      const token = localStorage.getItem("access_token");
+      if (!token) {
+        toast.error("Please login to continue");
+        return;
+      }
+
+      const baseUrl = API_BASE_URL.replace(/\/+$/, "");
+      const response = await fetch(`${baseUrl}/api/user-address/${addressId}?user_id=${user?.id}`, {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (response.ok) {
+        toast.success("Address deleted successfully");
+        await loadAddresses();
+        if (selectedAddressId === addressId) {
+          setSelectedAddressId(null);
+        }
+      } else {
+        const errorData = await response.json();
+        toast.error(errorData.message || "Failed to delete address");
+      }
+    } catch (error) {
+      console.error("Error deleting address:", error);
+      toast.error("Failed to delete address");
+    }
+  };
+
+  const handleAddressFormSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (!addressFormData.contact_name || !addressFormData.address_line1 || !addressFormData.city) {
+      toast.error("Please fill in all required fields");
+      return;
+    }
+
+    try {
+      setSavingAddress(true);
+      const token = localStorage.getItem("access_token");
+      if (!token) {
+        toast.error("Please login to continue");
+        return;
+      }
+
+      const baseUrl = API_BASE_URL.replace(/\/+$/, "");
+      const url = editingAddressId 
+        ? `${baseUrl}/api/user-address/${editingAddressId}`
+        : `${baseUrl}/api/user-address`;
+      
+      const method = editingAddressId ? "PUT" : "POST";
+      const requestData = {
+        ...addressFormData,
+        user_id: user?.id,
+      };
+
+      const response = await fetch(url, {
+        method,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(requestData),
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        toast.success(`Address ${editingAddressId ? 'updated' : 'added'} successfully`);
+        await loadAddresses();
+        
+        if (!editingAddressId && data.data?.address_id) {
+          setSelectedAddressId(data.data.address_id);
+        }
+        
+        setShowAddressForm(false);
+        setEditingAddressId(null);
+      } else {
+        const errorData = await response.json();
+        toast.error(errorData.message || `Failed to ${editingAddressId ? 'update' : 'add'} address`);
+      }
+    } catch (error) {
+      console.error("Error saving address:", error);
+      toast.error(`Failed to ${editingAddressId ? 'update' : 'add'} address`);
+    } finally {
+      setSavingAddress(false);
+    }
+  };
+
+  const handleCountrySelect = (country: typeof COUNTRY_CODES[0]) => {
+    setSelectedCountry(country);
+    setShowCountryCodes(false);
+    setAddressFormData(prev => ({
       ...prev,
-      [name]: value
+      country_code: country.code,
+    }));
+  };
+
+  const handleAddressInputChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value, type } = e.target;
+    setAddressFormData(prev => ({
+      ...prev,
+      [name]: type === 'checkbox' ? (e.target as HTMLInputElement).checked : value,
     }));
   };
 
@@ -72,12 +374,15 @@ const ShopOrder: React.FC<ShopOrderProps> = ({ shopId, shopName }) => {
   };
 
   const handlePlaceOrder = async () => {
-    // Validate required fields
-    const requiredFields = ['firstName', 'lastName', 'email', 'phone', 'address', 'city', 'state', 'zipCode'];
-    const missingFields = requiredFields.filter(field => !customerDetails[field as keyof typeof customerDetails]);
-    
-    if (missingFields.length > 0) {
-      toast.error('Please fill in all required fields');
+    // Validate address selection
+    if (!selectedAddressId) {
+      toast.error('Please select or add a shipping address');
+      return;
+    }
+
+    // Validate payment method
+    if ((paymentMethod === "credit_card" || paymentMethod === "debit_card") && !selectedCardId) {
+      toast.error('Please select a payment card');
       return;
     }
 
@@ -88,28 +393,497 @@ const ShopOrder: React.FC<ShopOrderProps> = ({ shopId, shopName }) => {
 
     try {
       setIsPlacingOrder(true);
-      
-      // Here you would implement the actual order placement logic
-      // For now, we'll simulate a successful order
-      await new Promise(resolve => setTimeout(resolve, 2000));
-      
-      // Clear the cart after successful order
-      await clearShopCart(shopId);
-      
-      toast.success('Order placed successfully!');
-      navigate(`/shop${shopId}/order-confirmation`, { 
-        state: { 
-          orderId: 'ORD-' + Date.now(),
-          total: calculateTotal(),
-          shopName 
-        }
+      const token = localStorage.getItem("access_token");
+      if (!token) {
+        toast.error("Please login to continue");
+        return;
+      }
+
+      const baseUrl = API_BASE_URL.replace(/\/+$/, "");
+
+      // Calculate totals from cart (sent to backend as reference; backend will also validate)
+      const subtotal = cartItems.reduce((sum: number, item: ShopCartItem) => {
+        const unit = item.product.original_price || item.product.price;
+        return sum + unit * item.quantity;
+      }, 0);
+      const discount = 0;
+      const shipping = 0;
+      const tax = 0;
+      const total = subtotal - discount + shipping + tax;
+
+      const orderData = {
+        // Items (for transparency / potential backend use)
+        items: cartItems.map((item: ShopCartItem) => {
+          const unit = item.product.original_price || item.product.price;
+          const line = unit * item.quantity;
+          return {
+            product_id: item.shop_product_id,
+            product_name_at_purchase: item.product.name,
+            sku_at_purchase: "",
+            quantity: item.quantity,
+            unit_price_inclusive_gst: unit.toFixed(2),
+            line_item_total_inclusive_gst: line.toFixed(2),
+            final_price_for_item: line.toFixed(2),
+            selected_attributes: item.selected_attributes || {},
+          };
+        }),
+        // Amounts
+        subtotal_amount: subtotal.toFixed(2),
+        discount_amount: discount.toFixed(2),
+        tax_amount: tax.toFixed(2),
+        shipping_amount: shipping.toFixed(2),
+        total_amount: total.toFixed(2),
+        currency: "INR",
+        // Checkout selections
+        shipping_address_id: selectedAddressId,
+        billing_address_id: selectedAddressId,
+        payment_method: paymentMethod,
+        shipping_method_name: "Standard Shipping",
+        customer_notes: "",
+        internal_notes: "",
+        ...(selectedCardId && (paymentMethod === "credit_card" || paymentMethod === "debit_card") && {
+          payment_card_id: selectedCardId,
+        }),
+      };
+
+      const response = await fetch(`${baseUrl}/api/shops/${shopId}/orders`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(orderData),
       });
+
+      const responseData = await response.json();
+      
+      if (response.ok && responseData?.data) {
+        // Clear the cart after successful order
+        await clearShopCart(shopId);
+        
+        toast.success('Order placed successfully!');
+        navigate(`/shop${shopId}/order-confirmation`, { 
+          state: { 
+            orderId: responseData.data.order_id,
+            total: calculateTotal(),
+            shopName 
+          }
+        });
+      } else {
+        throw new Error(responseData?.message || 'Failed to place order');
+      }
     } catch (error) {
       console.error('Failed to place order:', error);
-      toast.error('Failed to place order. Please try again.');
+      toast.error(error instanceof Error ? error.message : 'Failed to place order. Please try again.');
     } finally {
       setIsPlacingOrder(false);
     }
+  };
+
+  const renderAddresses = () => {
+    if (addresses.length === 0) {
+      return (
+        <div className="mb-6">
+          <div className="text-center p-8 border border-gray-200 rounded-lg">
+            <MapPin className="w-12 h-12 text-gray-400 mx-auto mb-4" />
+            <h3 className="text-lg font-medium text-gray-900 mb-2">No saved addresses</h3>
+            <p className="text-gray-600 mb-4">Add your first address to continue with checkout</p>
+            <button
+              onClick={handleAddNewAddress}
+              className="bg-orange-500 text-white px-6 py-2 rounded-lg font-medium hover:bg-orange-600 transition-colors"
+            >
+              Add Address
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="mb-6">
+        <div className="flex justify-between items-center mb-3">
+          <h3 className="text-lg font-semibold">Delivery Address</h3>
+          <button
+            onClick={handleAddNewAddress}
+            className="text-orange-500 hover:text-orange-600 font-medium flex items-center gap-1"
+          >
+            <Plus className="w-4 h-4" />
+            Add New Address
+          </button>
+        </div>
+        <div className="grid grid-cols-1 gap-3">
+          {addresses.map((address) => (
+            <div
+              key={address.address_id}
+              className={`p-4 border rounded-lg cursor-pointer transition-colors ${
+                selectedAddressId === address.address_id
+                  ? "border-orange-500 bg-orange-50"
+                  : "border-gray-200 hover:border-orange-300"
+              }`}
+              onClick={() => handleAddressSelect(address)}
+            >
+              <div className="flex items-start justify-between">
+                <div className="flex items-start gap-3">
+                  <MapPin className="w-5 h-5 text-orange-500 mt-0.5" />
+                  <div>
+                    <p className="font-medium">{address.contact_name}</p>
+                    <p className="text-sm text-gray-600">
+                      {address.contact_phone}
+                    </p>
+                    <p className="text-sm text-gray-600 mt-1">
+                      {address.address_line1}
+                      {address.address_line2 && `, ${address.address_line2}`}
+                      {address.landmark && `, ${address.landmark}`}
+                    </p>
+                    <p className="text-sm text-gray-600">
+                      {address.city}, {address.state_province} {address.postal_code}
+                    </p>
+                    <div className="flex gap-2 mt-2">
+                      {address.is_default_shipping && (
+                        <span className="text-xs bg-green-100 text-green-800 px-2 py-1 rounded">
+                          Default Shipping
+                        </span>
+                      )}
+                      {address.is_default_billing && (
+                        <span className="text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded">
+                          Default Billing
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleEditAddress(address.address_id);
+                    }}
+                    className="p-1 text-gray-500 hover:text-orange-500"
+                    title="Edit address"
+                  >
+                    <Edit2 className="w-4 h-4" />
+                  </button>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setAddressToDelete(address);
+                      setDeleteModalOpen(true);
+                    }}
+                    className="p-1 text-gray-500 hover:text-red-500"
+                    title="Delete address"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  };
+
+  const renderAddressForm = () => {
+    return (
+      <div className="mb-6 border border-gray-200 rounded-lg p-6">
+        <div className="flex justify-between items-center mb-4">
+          <h3 className="text-lg font-semibold">
+            {editingAddressId ? 'Edit Address' : 'Add New Address'}
+          </h3>
+          <button
+            onClick={() => setShowAddressForm(false)}
+            className="p-1 text-gray-500 hover:text-gray-700"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+        <form onSubmit={handleAddressFormSubmit} className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium mb-1">
+                Full Name *
+              </label>
+              <input
+                type="text"
+                name="contact_name"
+                value={addressFormData.contact_name}
+                onChange={handleAddressInputChange}
+                className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-orange-500 focus:border-orange-500"
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">
+                Phone Number *
+              </label>
+              <div className="flex gap-2">
+                <div className="relative">
+                  <button
+                    type="button"
+                    onClick={() => setShowCountryCodes(!showCountryCodes)}
+                    className="flex items-center gap-1 px-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-orange-500 focus:border-orange-500"
+                  >
+                    {selectedCountry.phoneCode}
+                    <ChevronDown className="w-4 h-4" />
+                  </button>
+                  {showCountryCodes && (
+                    <div className="absolute z-10 mt-1 w-48 bg-white border border-gray-200 rounded-md shadow-lg max-h-60 overflow-auto">
+                      {COUNTRY_CODES.map((country) => (
+                        <button
+                          key={country.code}
+                          type="button"
+                          onClick={() => handleCountrySelect(country)}
+                          className="w-full text-left px-4 py-2 text-sm hover:bg-gray-100 focus:bg-gray-100"
+                        >
+                          {country.name} ({country.phoneCode})
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+                <input
+                  type="tel"
+                  name="contact_phone"
+                  value={addressFormData.contact_phone}
+                  onChange={handleAddressInputChange}
+                  className="flex-1 border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-orange-500 focus:border-orange-500"
+                  required
+                />
+              </div>
+            </div>
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">
+              Address Line 1 *
+            </label>
+            <input
+              type="text"
+              name="address_line1"
+              value={addressFormData.address_line1}
+              onChange={handleAddressInputChange}
+              className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-orange-500 focus:border-orange-500"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">
+              Address Line 2
+            </label>
+            <input
+              type="text"
+              name="address_line2"
+              value={addressFormData.address_line2}
+              onChange={handleAddressInputChange}
+              className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-orange-500 focus:border-orange-500"
+            />
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div>
+              <label className="block text-sm font-medium mb-1">City *</label>
+              <input
+                type="text"
+                name="city"
+                value={addressFormData.city}
+                onChange={handleAddressInputChange}
+                className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-orange-500 focus:border-orange-500"
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">
+                State/Province *
+              </label>
+              <input
+                type="text"
+                name="state_province"
+                value={addressFormData.state_province}
+                onChange={handleAddressInputChange}
+                className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-orange-500 focus:border-orange-500"
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">
+                Postal Code *
+              </label>
+              <input
+                type="text"
+                name="postal_code"
+                value={addressFormData.postal_code}
+                onChange={handleAddressInputChange}
+                className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-orange-500 focus:border-orange-500"
+                required
+              />
+            </div>
+          </div>
+          <div className="flex items-center gap-4">
+            <label className="flex items-center">
+              <input
+                type="checkbox"
+                name="is_default_shipping"
+                checked={addressFormData.is_default_shipping}
+                onChange={handleAddressInputChange}
+                className="mr-2 accent-orange-500"
+              />
+              <span className="text-sm">Set as default shipping address</span>
+            </label>
+            <label className="flex items-center">
+              <input
+                type="checkbox"
+                name="is_default_billing"
+                checked={addressFormData.is_default_billing}
+                onChange={handleAddressInputChange}
+                className="mr-2 accent-orange-500"
+              />
+              <span className="text-sm">Set as default billing address</span>
+            </label>
+          </div>
+          <div className="flex gap-3">
+            <button
+              type="submit"
+              disabled={savingAddress}
+              className="bg-orange-500 text-white px-6 py-2 rounded-lg font-medium hover:bg-orange-600 transition-colors disabled:bg-orange-300"
+            >
+              {savingAddress ? 'Saving...' : (editingAddressId ? 'Update Address' : 'Save Address')}
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowAddressForm(false)}
+              className="bg-gray-500 text-white px-6 py-2 rounded-lg font-medium hover:bg-gray-600 transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      </div>
+    );
+  };
+
+  const renderPaymentMethods = () => {
+    return (
+      <div className="mb-6">
+        <h3 className="text-lg font-semibold mb-4">Payment Method</h3>
+        <div className="space-y-3">
+          <label className="flex items-center p-4 border border-gray-200 rounded-lg cursor-pointer hover:border-orange-300 transition-colors">
+            <input
+              type="radio"
+              name="payment_method"
+              value="cash_on_delivery"
+              checked={paymentMethod === "cash_on_delivery"}
+              onChange={(e) => setPaymentMethod(e.target.value)}
+              className="mr-3 accent-orange-500"
+            />
+            <div className="flex items-center gap-3">
+              <div className="w-8 h-8 bg-green-100 rounded-full flex items-center justify-center">
+                <span className="text-green-600 font-bold text-sm">₹</span>
+              </div>
+              <div>
+                <p className="font-medium">Cash on Delivery</p>
+                <p className="text-sm text-gray-600">Pay when you receive the order</p>
+              </div>
+            </div>
+          </label>
+          
+          <label className="flex items-center p-4 border border-gray-200 rounded-lg cursor-pointer hover:border-orange-300 transition-colors">
+            <input
+              type="radio"
+              name="payment_method"
+              value="credit_card"
+              checked={paymentMethod === "credit_card"}
+              onChange={(e) => setPaymentMethod(e.target.value)}
+              className="mr-3 accent-orange-500"
+            />
+            <div className="flex items-center gap-3">
+              <CreditCard className="w-8 h-8 text-blue-600" />
+              <div>
+                <p className="font-medium">Credit Card</p>
+                <p className="text-sm text-gray-600">Pay securely with your credit card</p>
+              </div>
+            </div>
+          </label>
+          
+          <label className="flex items-center p-4 border border-gray-200 rounded-lg cursor-pointer hover:border-orange-300 transition-colors">
+            <input
+              type="radio"
+              name="payment_method"
+              value="debit_card"
+              checked={paymentMethod === "debit_card"}
+              onChange={(e) => setPaymentMethod(e.target.value)}
+              className="mr-3 accent-orange-500"
+            />
+            <div className="flex items-center gap-3">
+              <CreditCard className="w-8 h-8 text-green-600" />
+              <div>
+                <p className="font-medium">Debit Card</p>
+                <p className="text-sm text-gray-600">Pay with your debit card</p>
+              </div>
+            </div>
+          </label>
+        </div>
+        
+        {(paymentMethod === "credit_card" || paymentMethod === "debit_card") && (
+          <div className="mt-4">
+            {savedCards.length > 0 ? (
+              <div>
+                <h4 className="font-medium mb-3">Select a saved card</h4>
+                <div className="space-y-2">
+                  {savedCards.map((card) => (
+                    <label
+                      key={card.card_id}
+                      className={`flex items-center p-3 border rounded-lg cursor-pointer transition-colors ${
+                        selectedCardId === card.card_id
+                          ? "border-orange-500 bg-orange-50"
+                          : "border-gray-200 hover:border-orange-300"
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name="selected_card"
+                        value={card.card_id}
+                        checked={selectedCardId === card.card_id}
+                        onChange={() => setSelectedCardId(card.card_id)}
+                        className="mr-3 accent-orange-500"
+                      />
+                      <div className="flex items-center gap-3">
+                        <CreditCard className="w-6 h-6 text-gray-600" />
+                        <div>
+                          <p className="font-medium">
+                            {card.card_brand} •••• {card.last_four_digits}
+                          </p>
+                          <p className="text-sm text-gray-600">
+                            {card.card_holder_name} ({card.card_type})
+                          </p>
+                        </div>
+                      </div>
+                    </label>
+                  ))}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setShowCardForm(!showCardForm)}
+                  className="mt-3 text-orange-500 hover:text-orange-600 font-medium flex items-center gap-1"
+                >
+                  <Plus className="w-4 h-4" />
+                  Add New Card
+                </button>
+              </div>
+            ) : (
+              <div className="text-center p-6 border border-gray-200 rounded-lg">
+                <CreditCard className="w-12 h-12 text-gray-400 mx-auto mb-3" />
+                <p className="text-gray-600 mb-3">No saved cards found</p>
+                <button
+                  type="button"
+                  onClick={() => setShowCardForm(true)}
+                  className="bg-orange-500 text-white px-4 py-2 rounded-lg font-medium hover:bg-orange-600 transition-colors"
+                >
+                  Add Payment Card
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    );
   };
 
   if (isLoading) {
@@ -137,143 +911,27 @@ const ShopOrder: React.FC<ShopOrderProps> = ({ shopId, shopName }) => {
 
   return (
     <div className="min-h-screen bg-gray-50 py-8">
-      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="bg-white rounded-lg shadow-lg overflow-hidden">
           <div className="px-6 py-4 bg-orange-500">
-            <h1 className="text-2xl font-bold text-white">Place Order - {shopName}</h1>
+            <h1 className="text-2xl font-bold text-white">Checkout - {shopName}</h1>
           </div>
 
           <div className="p-6">
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-              {/* Customer Details Form */}
-              <div>
-                <h2 className="text-xl font-semibold mb-6">Shipping Information</h2>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      First Name *
-                    </label>
-                    <input
-                      type="text"
-                      name="firstName"
-                      value={customerDetails.firstName}
-                      onChange={handleInputChange}
-                      className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-orange-500"
-                      required
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Last Name *
-                    </label>
-                    <input
-                      type="text"
-                      name="lastName"
-                      value={customerDetails.lastName}
-                      onChange={handleInputChange}
-                      className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-orange-500"
-                      required
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Email *
-                    </label>
-                    <input
-                      type="email"
-                      name="email"
-                      value={customerDetails.email}
-                      onChange={handleInputChange}
-                      className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-orange-500"
-                      required
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Phone *
-                    </label>
-                    <input
-                      type="tel"
-                      name="phone"
-                      value={customerDetails.phone}
-                      onChange={handleInputChange}
-                      className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-orange-500"
-                      required
-                    />
-                  </div>
-                </div>
+              {/* Left Column - Address & Payment */}
+              <div className="space-y-6">
+                {/* Address Management */}
+                {renderAddresses()}
                 
-                <div className="mt-4">
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
-                    Address *
-                  </label>
-                  <textarea
-                    name="address"
-                    value={customerDetails.address}
-                    onChange={handleInputChange}
-                    rows={3}
-                    className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-orange-500"
-                    required
-                  />
-                </div>
-
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4">
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      City *
-                    </label>
-                    <input
-                      type="text"
-                      name="city"
-                      value={customerDetails.city}
-                      onChange={handleInputChange}
-                      className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-orange-500"
-                      required
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      State *
-                    </label>
-                    <input
-                      type="text"
-                      name="state"
-                      value={customerDetails.state}
-                      onChange={handleInputChange}
-                      className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-orange-500"
-                      required
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      ZIP Code *
-                    </label>
-                    <input
-                      type="text"
-                      name="zipCode"
-                      value={customerDetails.zipCode}
-                      onChange={handleInputChange}
-                      className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-orange-500"
-                      required
-                    />
-                  </div>
-                </div>
-
-                <div className="mt-4">
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
-                    Country
-                  </label>
-                  <input
-                    type="text"
-                    name="country"
-                    value={customerDetails.country}
-                    onChange={handleInputChange}
-                    className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-orange-500"
-                  />
-                </div>
+                {/* Address Form */}
+                {showAddressForm && renderAddressForm()}
+                
+                {/* Payment Methods */}
+                {renderPaymentMethods()}
               </div>
 
-              {/* Order Summary */}
+              {/* Right Column - Order Summary */}
               <div>
                 <h2 className="text-xl font-semibold mb-6">Order Summary</h2>
                 <div className="border border-gray-200 rounded-lg p-4">
@@ -304,7 +962,7 @@ const ShopOrder: React.FC<ShopOrderProps> = ({ shopId, shopName }) => {
 
                 <button
                   onClick={handlePlaceOrder}
-                  disabled={isPlacingOrder}
+                  disabled={isPlacingOrder || !selectedAddressId || ((paymentMethod === "credit_card" || paymentMethod === "debit_card") && !selectedCardId)}
                   className="w-full mt-6 bg-orange-500 hover:bg-orange-600 disabled:bg-orange-300 text-white py-3 px-6 rounded-lg font-semibold transition-colors flex items-center justify-center"
                 >
                   {isPlacingOrder ? (
@@ -316,11 +974,41 @@ const ShopOrder: React.FC<ShopOrderProps> = ({ shopId, shopName }) => {
                     'Place Order'
                   )}
                 </button>
+                
+                {!selectedAddressId && (
+                  <p className="text-red-500 text-sm mt-2 text-center">
+                    Please select or add a delivery address
+                  </p>
+                )}
+                
+                {(paymentMethod === "credit_card" || paymentMethod === "debit_card") && !selectedCardId && (
+                  <p className="text-red-500 text-sm mt-2 text-center">
+                    Please select or add a payment card
+                  </p>
+                )}
               </div>
             </div>
           </div>
         </div>
       </div>
+
+      {/* Confirmation Modal for Address Deletion */}
+      <ConfirmationModal
+        isOpen={deleteModalOpen}
+        title="Delete Address"
+        message={`Are you sure you want to delete the address for '${addressToDelete?.contact_name || "this address"}'? This action cannot be undone.`}
+        onConfirm={async () => {
+          if (addressToDelete) {
+            await handleDeleteAddress(addressToDelete.address_id);
+          }
+          setDeleteModalOpen(false);
+          setAddressToDelete(null);
+        }}
+        onCancel={() => {
+          setDeleteModalOpen(false);
+          setAddressToDelete(null);
+        }}
+      />
     </div>
   );
 };

--- a/src/pages/Shop/ShopOrderConfirmation.tsx
+++ b/src/pages/Shop/ShopOrderConfirmation.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+type Props = {
+  shopId: number;
+  shopName: string;
+};
+
+// Responsive confirmation page for Shop Orders (mirrors merchant confirmation style)
+const ShopOrderConfirmation: React.FC<Props> = ({ shopId, shopName }) => {
+  const navigate = useNavigate();
+  const location = useLocation() as any;
+  const orderId: string | undefined = location?.state?.orderId;
+  const total: number | undefined = location?.state?.total;
+
+  const goToShopHome = () => navigate(`/shop${shopId}`);
+  const viewOrders = () => navigate('/orders');
+  const continueShopping = () => navigate(`/shop${shopId}-allproductpage`);
+
+  return (
+    <div className="min-h-[60vh] flex items-center justify-center px-4">
+      <div className="w-full max-w-2xl">
+        <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 sm:p-8">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+            <div className="flex items-center gap-4">
+              <div className="w-14 h-14 shrink-0 bg-green-100 rounded-full flex items-center justify-center">
+                <svg className="w-7 h-7 text-green-600" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7" />
+                </svg>
+              </div>
+              <div>
+                <h2 className="text-xl sm:text-2xl font-semibold text-gray-900">Order placed successfully</h2>
+                <p className="text-sm text-gray-600">Thanks for shopping at {shopName}. We'll send updates as your items ship.</p>
+              </div>
+            </div>
+          </div>
+
+          {(orderId || total) && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4 mb-6">
+              {orderId && (
+                <div className="rounded-lg border border-gray-100 bg-gray-50 p-4">
+                  <p className="text-xs uppercase tracking-wide text-gray-500">Order ID</p>
+                  <p className="mt-1 font-semibold text-gray-900 break-all">{orderId}</p>
+                </div>
+              )}
+              {typeof total === 'number' && (
+                <div className="rounded-lg border border-gray-100 bg-gray-50 p-4">
+                  <p className="text-xs uppercase tracking-wide text-gray-500">Order Total</p>
+                  <p className="mt-1 font-semibold text-gray-900">₹{total.toFixed(2)}</p>
+                </div>
+              )}
+            </div>
+          )}
+
+          <div className="flex flex-col sm:flex-row gap-3 sm:gap-4">
+            <button
+              onClick={goToShopHome}
+              className="w-full sm:w-auto px-5 py-2.5 border border-gray-300 rounded-lg text-sm font-medium text-gray-900 bg-white hover:bg-gray-50 transition-colors"
+            >
+              Go to {shopName}
+            </button>
+            <button
+              onClick={continueShopping}
+              className="w-full sm:w-auto px-5 py-2.5 border border-orange-200 rounded-lg text-sm font-medium text-orange-600 bg-orange-50 hover:bg-orange-100 transition-colors"
+            >
+              Continue Shopping
+            </button>
+            <button
+              onClick={viewOrders}
+              className="w-full sm:w-auto px-5 py-2.5 rounded-lg text-sm font-medium text-white bg-orange-500 hover:bg-orange-600 transition-colors"
+            >
+              View Orders
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ShopOrderConfirmation;

--- a/src/pages/Shop/ShopOrderConfirmationWrapper.tsx
+++ b/src/pages/Shop/ShopOrderConfirmationWrapper.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import ShopOrderConfirmation from './ShopOrderConfirmation';
+
+export const Shop1OrderConfirmation: React.FC = () => (
+  <ShopOrderConfirmation shopId={1} shopName="Shop 1" />
+);
+
+export const Shop2OrderConfirmation: React.FC = () => (
+  <ShopOrderConfirmation shopId={2} shopName="Shop 2" />
+);
+
+export const Shop3OrderConfirmation: React.FC = () => (
+  <ShopOrderConfirmation shopId={3} shopName="Shop 3" />
+);
+
+export const Shop4OrderConfirmation: React.FC = () => (
+  <ShopOrderConfirmation shopId={4} shopName="Shop 4" />
+);

--- a/src/pages/Shop/shopcart.tsx
+++ b/src/pages/Shop/shopcart.tsx
@@ -144,7 +144,7 @@ const Shopcart: React.FC = () => {
   };
 
   const handleContinueShopping = () => {
-    navigate(`/shop${currentShopId}`);
+    navigate(`/shop${currentShopId}-allproductpage`);
   };
 
   const handleClearCart = async () => {


### PR DESCRIPTION
This pull request introduces a new responsive order confirmation page for each shop and integrates it into the app's routing. The confirmation page is shown after a successful order and provides users with order details and navigation options. Additionally, the "Continue Shopping" button on the cart page now leads to the shop's all products page for a more intuitive user experience.

**Order confirmation feature:**

* Added a new reusable component `ShopOrderConfirmation` that displays order success information, order ID, total, and navigation buttons.
* Created wrapper components for each shop (`Shop1OrderConfirmation`, `Shop2OrderConfirmation`, etc.) to pass shop-specific props to the confirmation component.
* Integrated order confirmation pages into the app's routing for all four shops in `src/App.tsx`. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R27) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R269-R272)

**Shopping experience improvement:**

* Updated the "Continue Shopping" button in the cart page (`shopcart.tsx`) to redirect users to the shop's all products page instead of the shop home.